### PR TITLE
Wrap the tag name in quotes, since it includes a ':'

### DIFF
--- a/ISSUE_TEMPLATE/bug.md
+++ b/ISSUE_TEMPLATE/bug.md
@@ -2,7 +2,7 @@
 name: Bug
 about: Bug report
 title: ''
-labels: type:bug
+labels: 'type:bug'
 assignees: ''
 
 ---

--- a/ISSUE_TEMPLATE/feature.md
+++ b/ISSUE_TEMPLATE/feature.md
@@ -2,7 +2,7 @@
 name: Feature
 about: Feature Request
 title: ''
-labels: type:enhancement
+labels: 'type:enhancement'
 assignees: ''
 
 ---

--- a/ISSUE_TEMPLATE/security.md
+++ b/ISSUE_TEMPLATE/security.md
@@ -2,7 +2,7 @@
 name: Security
 about: Security Report
 title: ''
-labels: type:bug
+labels: 'type:bug'
 assignees: ''
 
 ---


### PR DESCRIPTION
Issue templates are not working after #16. Not totally sure why, but the labels include a ':'. This PR wraps that in quotes just in case that's causing issues.