### PR TITLE
Adds config.yml for Issue Templates

### DIFF
--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: General Questions
+    url: https://github.com/orgs/paketo-buildpacks/discussions
+    about: Have a general question?
+  - name: Have a Conversation
+    url: https://paketobuildpacks.slack.com
+    about: Looking to have a conversation or get realtime feedback? Join us on Slack!


### PR DESCRIPTION
One more try, https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser says that you need a config.yml to configure the issue template chooser. Let's see if adding that help.